### PR TITLE
Network 1.0 migration

### DIFF
--- a/howto-2-network-1.0-migration.md
+++ b/howto-2-network-1.0-migration.md
@@ -167,4 +167,3 @@ For your next regular update, Quilt will provide you with a standard network 2.0
 Once everything has been updated, verify that you can a) login (via the database), and b) view packages in the Packages tab (via ElasticSearch).
 
 You may also want to run through a complete 'stack validation' to ensure there aren't any other difficulties.
-You may also want to run through a complete 'stack validation' to ensure there aren't any other difficulties.


### PR DESCRIPTION
This PR introduces comprehensive documentation for migrating from Network 1.0 (legacy flat VPC design) to Network 2.0 (three-tier subnet architecture) in Quilt stacks. The migration provides enhanced security through proper network segmentation while preserving existing data resources.

Key changes:
- Documents Network 1.0 vs 2.0 architectural differences and motivations for migration
- Provides step-by-step migration process through intermediate "Network 1.5" transitional stack
- Details specific procedures for reconfiguring RDS, Elasticsearch, and security groups



