### PR TITLE
Tessera network migration notes

### DIFF
--- a/howto-2-network-1.0-migration.md
+++ b/howto-2-network-1.0-migration.md
@@ -18,7 +18,7 @@ Guidance on migrating from a legacy single-tier VPC setup (Network 1.0) to the m
 
 ### What Is Network 1.0?
 
-Network 1.0 is a **legacy flat VPC design** used for earlier stacks. It lacks formal network segmentation, placing all resources -- databases, load balancers, services -- in the same subnet and availability zone.
+Network 1.0 is a **legacy flat VPC design** used for earlier stacks. It lacks formal network segmentation, placing all resources—databases, load balancers, services—in the same subnet and availability zone.
 
 ### What Is Network 2.0?
 
@@ -194,10 +194,8 @@ Since it's impossible to directly change DBSubnetGroup subnets when in use, use 
 
 - DBSubnetGroup subnets cannot be changed when in use
 - CloudFormation can only change DBSubnetGroup by replacing the DB instance
-- A new DBSubnetGroup cannot be in the same VPC as an existing one
+- A new DBSubnetGroup cannot be in the same VPC as an existing one (this is why a temporary VPC is required during migration)
 - Moving to a new DBSubnetGroup requires Multi-AZ to be turned off temporarily
-
-⚠️ **Important**: A new DBSubnetGroup cannot be created in the same VPC as an existing one. This is why a temporary VPC is required during migration.
 
 **Migration Steps:**
 

--- a/tessera-network-migration.md
+++ b/tessera-network-migration.md
@@ -23,9 +23,13 @@
 
 ## Migration Steps
 
-### Step 0: make backups of DB and ES?
+### Step 0: Create Backups of Database and Elasticsearch
 
-### Step 1: make a new variant option for api_gateway_in_vpc=True?
+Before beginning the migration, create backups of your database and Elasticsearch cluster to ensure data safety during the transition process.
+
+### Step 1: Configure API Gateway VPC Setting
+
+Create a new variant with `api_gateway_in_vpc=true` to enable API Gateway within the VPC.
 
 They'll need to create a VPC endpoint for API Gateway and pass it to `ApiGatewayVPCEndpoint` parameter
 
@@ -46,9 +50,9 @@ They'll need to create a VPC endpoint for API Gateway and pass it to `ApiGateway
 - a new DBSubnetGroup can't be in the same VPC
 - moving to new DBSubnetGroup requires multi-AZ to be turned off temporarily
 
-#### Steps (TODO: provide script?)
+#### Steps
 
-1. create temporary VPC with 2 subnets in different AZs, restrictive security group and new DBSubnetGroup (TODO: provide CloudFormation template?)
+1. create temporary VPC with 2 subnets in different AZs, restrictive security group and new DBSubnetGroup
 2. turn off multi-AZ on DB instance
 3. modify DB instance to use new DBSubnetGroup in temporary VPC
 4. set IntraSubnets on old DBSubnetGroup


### PR DESCRIPTION
This PR exteneds migration documentation for upgrading networks from version 1.0 to 2.0, explicitly to support Tessera The migration involves significant networking changes including the addition of multiple subnet pairs and specific configuration requirements.

- Documents the key differences between Network 1.0 and 2.0, including subnet architecture changes and required configuration values
- Provides step-by-step migration procedures including database subnet migration and VPC resource preparation
- Outlines Tessera-specific considerations and CloudFormation parameter changes needed for the upgrade

The expectation is that we will remove tessera-specific details before merging this PR.