### PR TITLE
Update 1.69.0 release notes

### DIFF
--- a/release-notes/1-69-0-release-notes.md
+++ b/release-notes/1-69-0-release-notes.md
@@ -1,6 +1,6 @@
 # Platform Update 1.69
 
-## Qurator Platform Tools, Async Benchling Pipeline, Union-of-Roles SSO, QuiltSync Updates, Prefix Reindex
+## Qurator Platform Tools, Benchling Auto-Updates, Multi-Role SSO, Streamlined QuiltSync
 
 This release enhances Qurator with first-class access to platform MCP tools, supports auto-updating Benchling canvases, grants SSO users access to multiple roles, adds major QuiltSync workflow improvements, and enables partial reindexing of buckets.
 
@@ -12,7 +12,7 @@ Qurator can now use the platform's MCP tools — package browse and search, obje
 
 ### Asynchronous Benchling Integration
 
-The Benchling canvas now updates asynchronously as Quilt re-exports packages, showing a "pending → complete" state and remaining browsable throughout the re-export. In addition, Benchling `reviewRecord` events will also trigger package updates.
+The Benchling canvas now updates asynchronously whenever Quilt updates packages, and shows as pending when first creating a package. Benchling reviewRecord events can also trigger package updates. In addition, Benchling `reviewRecord` events will also trigger package updates.
 
 ### Union-of-Roles SSO Mode
 
@@ -39,9 +39,9 @@ The Admin > Theme editor in Admin Settings now lets you optionally upload a cata
 
 ## Stack Admin Improvements
 
-- **Admin Bucket Listings Respect Role Scope:** User-facing bucket listings (catalog navbar, landing grid, search filter, and the MCP `bucket_list` tool) no longer bypass role scope for admins.
+- **Admin Bucket Listings Respect Role Scope:** Admin users now see role-appropriate bucket listings (catalog navbar, landing grid, search filter, and the MCP `bucket_list` tool) instead of all buckets.
 - **Wildcard Connect Hosts:** `ConnectAllowedHosts` now supports leading-dot domain suffixes (e.g. `.benchling.com`) to allow any subdomain over HTTPS.
-- **Bucket Management Lockdown:** Manual bucket management operations on stack-managed S3 buckets are now denied by bucket policy. All bucket configuration changes must go through CloudFormation.
+- **Stack-Managed Bucket Protections:** Manual bucket management operations on stack-managed S3 buckets are now denied by bucket policy. All bucket configuration changes must go through CloudFormation.
 
 ## Other Improvements
 

--- a/release-notes/1-69-0-release-notes.md
+++ b/release-notes/1-69-0-release-notes.md
@@ -2,47 +2,39 @@
 
 ## Qurator Platform Tools, Async Benchling Pipeline, Union-of-Roles SSO, Prefix Reindex
 
-This release expands Qurator with first-class platform data tools, makes the Benchling integration fully asynchronous, introduces an opt-in union-of-roles mode for SSO, and lets administrators rescan a single prefix instead of the whole bucket.
+This release enhances Qurator with first-class access to platform MCP tools, support auto-update of Benchling canvases, grants SSO users access to multiple roles, and enables partial reindexing of buckets.
 
 ## New Quilt Platform Features
 
 ### Qurator Platform Tools
 
-Qurator can now use the platform's data tools — package browse and search, object search, S3 reads, Athena queries, tabulator, and package create/edit — alongside its existing in-catalog navigation. Tools execute under the user's catalog session, so all access continues to respect existing role and bucket permissions.
-
-To support this, the Platform MCP Server now also deploys when Qurator is enabled (in addition to Connect) and is served from the main ALB at `registry-<stack>.<domain>/mcp/platform/*`, so the Qurator assistant can call it with the user's session token. Stacks that don't enable Qurator are unaffected.
+Qurator can now use the platform's MCP tools — package browse and search, object search, S3 reads, Athena queries, tabulator, and package create/edit — alongside its existing in-catalog navigation. Tools execute under the user's catalog session, so all access continues to respect existing role and bucket permissions.  This works even if Quilt Connect is not activated for public MCP access.
 
 ### Asynchronous Benchling Integration
 
-The Benchling canvas now updates asynchronously as Quilt re-exports packages, showing a "pending → complete" state and remaining browsable throughout the re-export. In addition, Benchling `reviewRecord` entry events now trigger the standard package export workflow, bringing review records into parity with other entry types.
+The Benchling canvas now updates asynchronously as Quilt re-exports packages, showing a "pending → complete" state and remaining browsable throughout the re-export. In addition, Benchling `reviewRecord` events will also trigger package updates.
 
 ### Union-of-Roles SSO Mode
 
-A new opt-in `union_roles: true` flag in SSO config changes role assignment from first-match-wins to a union of **all** matching mapping roles. Users switch among the assigned roles via the existing role switcher, and any role no longer in the match set is revoked on next login. Default behavior is unchanged — existing SSO configs see no difference.
-
-Under `union_roles`, the mapping `admin` field becomes tri-state: omitted means non-vote, `true` grants admin, and `false` vetoes — an explicit `admin: false` blocks admin even if another matching mapping grants it.
+Adminstrators can use the new `union_roles: true` flag in their SSO configuration to grant users access to **all** matching roles, instead of just the first. Users can switch among the assigned roles via the existing role switcher, and any role no longer in the match set is revoked on next login. Default behavior is unchanged — existing SSO configurations will see no difference.
 
 ### Prefix-Scoped Reindex
 
-Stack admins can now scope a reindex to a single prefix. `POST /api/admin/reindex/<bucket>` accepts an optional `prefix` field; when supplied, Elasticsearch indices are left in place and only keys under that prefix are re-walked. Concurrent prefix reindexes on distinct prefixes are allowed; same-prefix and full-vs-prefix collisions return HTTP 409.
+Stack admins can now scope a bucket reindexing to a single prefix. `POST /api/admin/reindex/<bucket>` accepts an optional `prefix` field; when supplied, Elasticsearch indices are left in place and only keys under that prefix are re-walked.
 
 ### Admin Theme Logo Upload
 
-The Admin > Theme editor now lets you upload a catalog logo file directly (PNG, JPEG, WebP, or GIF), replacing the previous URL-only flow.
+The Admin > Theme editor in Adimin Settings now lets you optionally upload a catalog logo file directly (PNG, JPEG, WebP, or GIF), extending the previous URL-only flow.
 
 ## Stack Admin Improvements
 
-- **Bucket Management Lockdown:** Manual bucket management operations on stack-managed S3 buckets are now denied by bucket policy. All bucket configuration changes must go through CloudFormation.
 - **Admin Bucket Listings Respect Role Scope:** User-facing bucket listings (catalog navbar, landing grid, search filter, and the MCP `bucket_list` tool) no longer bypass role scope for admins.
 - **Wildcard Connect Hosts:** `ConnectAllowedHosts` now supports leading-dot domain suffixes (e.g. `.benchling.com`) to allow any subdomain over HTTPS.
-- **s3-proxy Base Image:** Bumped to an updated Amazon Linux 2023 base image.
-
-## Bug Fixes
-
-- Fixed Admin > Theme **Save** silently failing with a 403 on managed-role stacks (the modern default); the settings JSON write is now granted to `ManagedUserRoleBasePolicy`.
-- Fixed an "Error resolving revision" flash that briefly appeared when navigating to a just-created package.
-- Fixed Okta `ClientId` and `BaseUrl` in Terraform configs.
+- **Bucket Management Lockdown:** Manual bucket management operations on stack-managed S3 buckets are now denied by bucket policy. All bucket configuration changes must go through CloudFormation.
 
 ## Other Improvements
 
-- Removed the unused "Overview URL" and "Structured data (JSON-LD)" fields from the Admin Buckets editor, along with the obsolete OPEN-stack features they enabled.
+- **s3-proxy Base Image:** Bumped to an updated Amazon Linux 2023 base image.
+- Fixed an "Error resolving revision" flash that briefly appeared when navigating to a just-created package.
+- Fixed Admin > Theme **Save** silently failing with a 403 on managed-role stacks (the modern default).
+- Removed the unused "Overview URL" and "Structured data (JSON-LD)" fields from the Admin Buckets editor.

--- a/release-notes/1-69-0-release-notes.md
+++ b/release-notes/1-69-0-release-notes.md
@@ -1,0 +1,48 @@
+# Platform Update 1.69
+
+## Qurator Platform Tools, Async Benchling Pipeline, Union-of-Roles SSO, Prefix Reindex
+
+This release expands Qurator with first-class platform data tools, makes the Benchling integration fully asynchronous, introduces an opt-in union-of-roles mode for SSO, and lets administrators rescan a single prefix instead of the whole bucket.
+
+## New Quilt Platform Features
+
+### Qurator Platform Tools
+
+Qurator can now use the platform's data tools — package browse and search, object search, S3 reads, Athena queries, tabulator, and package create/edit — alongside its existing in-catalog navigation. Tools execute under the user's catalog session, so all access continues to respect existing role and bucket permissions.
+
+To support this, the Platform MCP Server now also deploys when Qurator is enabled (in addition to Connect) and is served from the main ALB at `registry-<stack>.<domain>/mcp/platform/*`, so the Qurator assistant can call it with the user's session token. Stacks that don't enable Qurator are unaffected.
+
+### Asynchronous Benchling Integration
+
+The Benchling canvas now updates asynchronously as Quilt re-exports packages, showing a "pending → complete" state and remaining browsable throughout the re-export. In addition, Benchling `reviewRecord` entry events now trigger the standard package export workflow, bringing review records into parity with other entry types.
+
+### Union-of-Roles SSO Mode
+
+A new opt-in `union_roles: true` flag in SSO config changes role assignment from first-match-wins to a union of **all** matching mapping roles. Users switch among the assigned roles via the existing role switcher, and any role no longer in the match set is revoked on next login. Default behavior is unchanged — existing SSO configs see no difference.
+
+Under `union_roles`, the mapping `admin` field becomes tri-state: omitted means non-vote, `true` grants admin, and `false` vetoes — an explicit `admin: false` blocks admin even if another matching mapping grants it.
+
+### Prefix-Scoped Reindex
+
+Stack admins can now scope a reindex to a single prefix. `POST /api/admin/reindex/<bucket>` accepts an optional `prefix` field; when supplied, Elasticsearch indices are left in place and only keys under that prefix are re-walked. Concurrent prefix reindexes on distinct prefixes are allowed; same-prefix and full-vs-prefix collisions return HTTP 409.
+
+### Admin Theme Logo Upload
+
+The Admin > Theme editor now lets you upload a catalog logo file directly (PNG, JPEG, WebP, or GIF), replacing the previous URL-only flow.
+
+## Stack Admin Improvements
+
+- **Bucket Management Lockdown:** Manual bucket management operations on stack-managed S3 buckets are now denied by bucket policy. All bucket configuration changes must go through CloudFormation.
+- **Admin Bucket Listings Respect Role Scope:** User-facing bucket listings (catalog navbar, landing grid, search filter, and the MCP `bucket_list` tool) no longer bypass role scope for admins.
+- **Wildcard Connect Hosts:** `ConnectAllowedHosts` now supports leading-dot domain suffixes (e.g. `.benchling.com`) to allow any subdomain over HTTPS.
+- **s3-proxy Base Image:** Bumped to an updated Amazon Linux 2023 base image.
+
+## Bug Fixes
+
+- Fixed Admin > Theme **Save** silently failing with a 403 on managed-role stacks (the modern default); the settings JSON write is now granted to `ManagedUserRoleBasePolicy`.
+- Fixed an "Error resolving revision" flash that briefly appeared when navigating to a just-created package.
+- Fixed Okta `ClientId` and `BaseUrl` in Terraform configs.
+
+## Other Improvements
+
+- Removed the unused "Overview URL" and "Structured data (JSON-LD)" fields from the Admin Buckets editor, along with the obsolete OPEN-stack features they enabled.

--- a/release-notes/1-69-0-release-notes.md
+++ b/release-notes/1-69-0-release-notes.md
@@ -1,8 +1,8 @@
 # Platform Update 1.69
 
-## Qurator Platform Tools, Async Benchling Pipeline, Union-of-Roles SSO, Prefix Reindex
+## Qurator Platform Tools, Async Benchling Pipeline, Union-of-Roles SSO, QuiltSync Updates, Prefix Reindex
 
-This release enhances Qurator with first-class access to platform MCP tools, support auto-update of Benchling canvases, grants SSO users access to multiple roles, and enables partial reindexing of buckets.
+This release enhances Qurator with first-class access to platform MCP tools, supports auto-updating Benchling canvases, grants SSO users access to multiple roles, adds major QuiltSync workflow improvements, and enables partial reindexing of buckets.
 
 ## New Quilt Platform Features
 
@@ -16,7 +16,7 @@ The Benchling canvas now updates asynchronously as Quilt re-exports packages, sh
 
 ### Union-of-Roles SSO Mode
 
-Adminstrators can use the new `union_roles: true` flag in their SSO configuration to grant users access to **all** matching roles, instead of just the first. Users can switch among the assigned roles via the existing role switcher, and any role no longer in the match set is revoked on next login. Default behavior is unchanged — existing SSO configurations will see no difference.
+Administrators can use the new `union_roles: true` flag in their SSO configuration to grant users access to **all** matching roles, instead of just the first. Users can switch among the assigned roles via the existing role switcher, and any role no longer in the match set is revoked on next login. Default behavior is unchanged — existing SSO configurations will see no difference.
 
 ### Prefix-Scoped Reindex
 
@@ -24,7 +24,18 @@ Stack admins can now scope a bucket reindexing to a single prefix. `POST /api/ad
 
 ### Admin Theme Logo Upload
 
-The Admin > Theme editor in Adimin Settings now lets you optionally upload a catalog logo file directly (PNG, JPEG, WebP, or GIF), extending the previous URL-only flow.
+The Admin > Theme editor in Admin Settings now lets you optionally upload a catalog logo file directly (PNG, JPEG, WebP, or GIF), extending the previous URL-only flow.
+
+## New QuiltSync Release
+
+- **Commit and Push Workflow:** QuiltSync now includes a one-step **Commit and Push** action for publishing local package changes. The action is available from the installed packages list, the commit form, and the installed package page, with settings for default message templates, workflow selection, and metadata.
+- **OAuth Login:** QuiltSync now supports browser-based OAuth 2.1 login via `quilt://` deep links, with legacy code-based login retained as a fallback for stacks that do not support OAuth.
+- **Local Package Creation and First Push:** Users can create local packages directly in QuiltSync, optionally choose a source directory, set a remote, and complete the first-push workflow from the app.
+- **`.quiltignore` Support:** QuiltSync surfaces junk file detection badges and ignore/un-ignore controls, then filters ignored entries during package operations.
+- **Diagnostics from Settings:** The former debug toolbar has been replaced by a Settings page that can collect diagnostic logs and send them to Quilt support through Sentry or email.
+- **Faster Package Views:** Installed packages now render immediately from cached lineage while QuiltSync refreshes per-package status in the background.
+- **Release and UI Polish:** QuiltSync now shows release notes inside the app, uses Quilt.bio branding, prevents empty commit messages, highlights packages with uncommitted changes, and protects pulls when local changes would be overwritten.
+- **Reliability Improvements:** The underlying `quilt-rs` client now retries transient HTTP failures with backoff, refreshes expired S3 credentials per request, redacts secrets from debug logs, and uses atomic storage writes.
 
 ## Stack Admin Improvements
 

--- a/release-notes/1-69-0-release-notes.md
+++ b/release-notes/1-69-0-release-notes.md
@@ -8,7 +8,7 @@ This release enhances Qurator with first-class access to platform MCP tools, sup
 
 ### Qurator Platform Tools
 
-Qurator can now use the platform's MCP tools — package browse and search, object search, S3 reads, Athena queries, tabulator, and package create/edit — alongside its existing in-catalog navigation. Tools execute under the user's catalog session, so all access continues to respect existing role and bucket permissions.  This works even if Quilt Connect is not activated for public MCP access.
+Qurator can now use the platform's MCP tools — package browse and search, object search, S3 reads, Athena queries, tabulator, and package create/edit — alongside its existing in-catalog navigation. Tools execute under the user's catalog session, so all access continues to respect existing role and bucket permissions. This works even if Quilt Connect is not activated for public MCP access.
 
 ### Asynchronous Benchling Integration
 

--- a/release-notes/1-69-0-release-notes.md
+++ b/release-notes/1-69-0-release-notes.md
@@ -40,7 +40,7 @@ The Admin > Theme editor in Admin Settings now lets you optionally upload a cata
 ## Stack Admin Improvements
 
 - **Admin Bucket Listings Respect Role Scope:** Admin users now see role-appropriate bucket listings (catalog navbar, landing grid, search filter, and the MCP `bucket_list` tool) instead of all buckets.
-- **Wildcard Connect Hosts:** `ConnectAllowedHosts` now supports leading-dot domain suffixes (e.g. `.benchling.com`) to allow any subdomain over HTTPS.
+- **Subdomain Wildcards for Connect Hosts:** `ConnectAllowedHosts` now accepts leading-dot entries (e.g. `.benchling.com`) that match any subdomain over HTTPS at any depth (e.g. `app.benchling.com`, `app.us.benchling.com`); the apex domain is not matched.
 - **Stack-Managed Bucket Protections:** Manual bucket management operations on stack-managed S3 buckets are now denied by bucket policy. All bucket configuration changes must go through CloudFormation.
 
 ## Other Improvements


### PR DESCRIPTION
## Summary

- Update the 1.69.0 release notes wording for the release overview and feature sections.
- Reorganize several stack admin and other improvement bullets.

## Validation

- Not run; documentation-only release notes change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds release notes for the 1.69.0 platform update, covering five major platform features (Qurator MCP tools, async Benchling integration, Union-of-Roles SSO, prefix-scoped reindex, admin logo upload), a comprehensive QuiltSync release, stack admin improvements, and miscellaneous bug fixes. The document is well-organized and clearly written, with only a minor double-space typographical issue on line 11.

<h3>Confidence Score: 5/5</h3>

Documentation-only change; safe to merge.

No code changes are introduced. The only finding is a minor double-space in prose, which is a P2 style issue. All content appears accurate, complete, and well-structured.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| release-notes/1-69-0-release-notes.md | New release notes file for v1.69.0 covering Qurator MCP tools, async Benchling integration, Union-of-Roles SSO, QuiltSync updates, prefix reindex, and stack admin improvements — one minor double-space typo on line 11. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Platform Update 1.69] --> B[New Platform Features]
    A --> C[New QuiltSync Release]
    A --> D[Stack Admin Improvements]
    A --> E[Other Improvements]

    B --> B1[Qurator Platform MCP Tools]
    B --> B2[Async Benchling Integration]
    B --> B3[Union-of-Roles SSO]
    B --> B4[Prefix-Scoped Reindex]
    B --> B5[Admin Theme Logo Upload]

    C --> C1[Commit and Push Workflow]
    C --> C2[OAuth 2.1 Login]
    C --> C3[Local Package Creation]
    C --> C4[.quiltignore Support]
    C --> C5[Diagnostics from Settings]
    C --> C6[Faster Package Views]

    D --> D1[Bucket Listings Respect Role Scope]
    D --> D2[Wildcard Connect Hosts]
    D --> D3[Bucket Management Lockdown]
```

<sub>Reviews (1): Last reviewed commit: ["Refine 1.69 release notes wording"](https://github.com/quiltdata/knowledge-base/commit/f07114bae71f631d1ac3b7fa88adce5cd7030ae0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30284236)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->