### PR TITLE
Release notes: Platform Update 1.71

### DIFF
--- a/release-notes/1-70+71-release-notes.md
+++ b/release-notes/1-70+71-release-notes.md
@@ -1,0 +1,126 @@
+# Platform Update 1.71
+
+Quilt Connect now also works on private stacks, and adds support for Databricks, ChatGPT, and Codex as MCP clients. This release also moves package metadata to per-bucket Iceberg tables for faster and cheaper querying, especially from Tabulator, and adds Glacier rehydration from file preview. Benchling entries gain referenced-entity search and multi-bucket search, while QuiltSync adds a CLI, background Autosync and workflows.
+
+## New Quilt Platform Features
+
+### Private Quilt Connect
+
+Quilt Connect now uses the same network configuration as the rest of your Quilt stack. This allows OAuth sign-in to the Quilt Platform MCP Server from local MCP clients such as Claude Code, even if you don't have a public endpoint or are using a web-application firewall.
+
+### MCP Support for Databricks, ChatGPT, and Codex
+
+Quilt Connect now supports Databricks, ChatGPT, and Codex as MCP clients. Stack admins can specify Databricks and ChatGPT hosts in `ConnectAllowedHosts`, or use `localhost` for access by Codex.
+
+### Benchling Entities and Cross-Bucket Search
+
+This release bundles v0.19 of the Benchling Webhook:
+
+- Each auto-generated entry package contains the full list of referenced objects, as both package metadata and a `links.json` file. This includes both the unique identifier and human-readable names, so you can search or query to find every experiment that references plasmid QB-2743.1.
+- You can also disable automatic package creation by not setting a default bucket. Instead, the App Canvas will use the new Iceberg catalog to automatically search every bucket for packages with metadata that reference the notebook name (e.g., `experiment_id = EXP00012345`) and display those instead.
+
+### Iceberg Package Metadata
+
+Quilt users can now query package metadata directly as Iceberg tables in Athena — package revisions, tags, manifests, and entries — instead of relying on Athena crawling individual JSONL manifests on every query. If you can read a bucket in the catalog, you can query the Iceberg tables for it using your existing session credentials.
+
+This uses per-bucket tables of the form:
+
+```text
+{bucket}_package_{revision,tag,manifest,entry}
+```
+
+Tabulator and in-catalog package surfaces use the new layout transparently, and Tabulator queries now hit this index instead of doing a full S3 scan through Glue/Athena SerDe tables — cheaper and faster end-to-end, with permissions unchanged.
+
+> **NOTE:** External consumers of the old global tables must migrate to the per-bucket names and use `UNION ALL` for cross-bucket queries.
+
+### Glacier Rehydration from File Preview
+
+Archived S3 objects in Glacier or Deep Archive can now be restored directly from file preview in the Quilt Catalog. Choose restore tier and duration; Quilt tracks restore state from S3 metadata, and managed read/write roles get `s3:RestoreObject`.
+
+## QuiltSync & CLI
+
+### Background Autosync
+
+QuiltSync adds an opt-in Autosync loop with independent Pull and Push toggles. Auto-pull refreshes latest for installed remote packages when the working tree is clean; auto-push can commit and publish quiet local changes using your publish settings, while pausing on pending changes or divergence.
+
+A tray-resident shell keeps Autosync running with the main window closed. The optional Close to tray setting hides the window instead of quitting, and the tray shows idle, syncing, paused, or error status with Open Quilt and Quit actions.
+
+A per-mapping filesystem watcher refreshes local package status when files change on disk, so status badges and entry lists update within about 500 ms without a reload. The watcher is guarded against feedback loops and only repaints when computed status changes.
+
+[Get QuiltSync](https://quilt.bio/quiltsync/)
+
+### Workflow Configuration
+
+QuiltSync now enables you to specify per-bucket workflows, which is particularly useful with locally-created packages.
+
+### Clearer Merge Actions
+
+The merge page now labels actions by direction: **Promote my commit** pushes the local commit and tags it latest, while **Overwrite local with remote** resets local state and discards uncommitted edits.
+
+### quilt-cli on crates.io
+
+The new QuiltSync-based `quilt` CLI is now published to crates.io with prebuilt binaries for macOS and Linux, installable via `cargo binstall quilt-cli`. This is tightly integrated with QuiltSync's data directory so you can use either the CLI or the GUI to manage your packages.
+
+### Robust Image Previewing
+
+- Multi-channel images render ~12–25% faster, and large floating-point multi-channel images near the memory limit now render reliably.
+- A channel containing NaN or infinite pixel values no longer blanks the entire thumbnail.
+- Color CZI images stored in BGR pixel formats (e.g. `Bgr24` / `Bgr48`) now preview with correct colors.
+- Signed and wider-than-16-bit integer images (`uint32` / `uint64`, `int8`, `int64`, and 32-bit-integer color) now preview contrast-stretched, instead of failing or rendering dark.
+- `.jpeg`/`.webp` thumbnails, float and 16-bit-color images, and 16-bit greyscale now render correctly.
+- Previews are now 8-bit everywhere, producing smaller PNGs with no loss of meaningful detail.
+- The source image streams to disk during rendering instead of buffering fully in memory, lowering peak memory on large images.
+
+### Other Catalog Improvements
+
+- Landing page bucket cards now show configured bucket icons, matching the navbar selector.
+- An expired or rejected session now reliably redirects to sign-in instead of showing a generic error page.
+- The Admin > Theme logo preview no longer breaks the editor when the configured S3 URL is malformed.
+- Markdown file previews now render using standard GitHub-Flavored Markdown (a superset of CommonMark). This means we no longer support idiosyncratic Pandoc/PHP-Markdown-Extra shortcuts.
+- Syntax highlighting now loads language grammars on demand instead of all up front; code in an unsupported or unrecognized language is no longer highlighted.
+- The Athena Queries tab no longer errors for accounts with more than 50 Athena workgroups.
+
+## Stack Admin Improvements
+
+### Lake Formation Grants (Opt-In)
+
+A new `EnableLakeFormationGrants` stack parameter emits PrincipalPermissions grants from stack service roles to the data lake. If your AWS account enforces Lake Formation on the data lake, you must enable this parameter — otherwise Lake Formation denies the stack's roles and per-bucket Iceberg access (among other things) breaks. It is opt-in and off by default; leave it off only on accounts that do not enforce Lake Formation.
+
+### Other Stack Improvements
+
+- The Quilt Platform MCP server now returns the full package revision hash, avoiding errors due to truncated hashes. Registry errors are now also properly surfaced by the tool. The `package_create` tool avoids overwriting existing packages, steering clients to `package_patch` unless overridden (in which case it reports the diff).
+- The registry now uses the mimalloc allocator instead of pymalloc, lowering per-worker memory and eliminating intermittent out-of-memory worker kills that surfaced as a catalog "Unexpected Error".
+- Obsolete global Iceberg package tables are now cleaned up via S3 lifecycle expiration instead of a synchronous Athena `DROP TABLE` that could time out on large stacks; the Iceberg Glue database name is now exposed as the `IcebergDatabaseName` stack output.
+- The CloudWatch Synthetics canary runtime is now Node 22 / Synthetics 15.1, replacing the previous v10 runtime that is on AWS's deprecation path.
+- Customers still on Network 1.0 can easily migrate to Network 2.0 for improved security and configurability.
+
+> These already shipped as part of the 1.69.4 security update, but are included here for completeness.
+
+- Postgres engine upgraded to 15.18 for CloudFormation deployments.
+- s3-proxy: nginx upgraded 1.24.0 → 1.30.2 with a refreshed Amazon Linux base image.
+
+## Your CloudFormation Template
+
+Find the CloudFormation YAML file available via the link below:
+
+| Field            | Value                     |
+| ---------------- | ------------------------- |
+| Catalog URL      | No URL Found              |
+| Template URL     | No Template Variant Found |
+| Deployment Style | CF                        |
+| Network Version  | 2                         |
+
+For more information on how to apply this release for CloudFormation (CF), refer to our upgrade documentation or full installation guide.
+
+Terraform users (TF) can use the public quilt module.
+
+Please contact [support@quilt.bio](mailto:support@quilt.bio) if you have any questions.
+
+---
+
+Quilt Data, 595 Pacific Avenue, Floor 4, San Francisco, California, 94133, United States
+
+781-277-2255
+
+Unsubscribe · Manage Preferences
+</content>

--- a/release-notes/1-71-0-release-notes.md
+++ b/release-notes/1-71-0-release-notes.md
@@ -1,0 +1,72 @@
+# Platform Update 1.71
+
+This release expands Quilt Connect (OAuth sign-in from local MCP clients now works on WAF-protected stacks, plus a safer `package_create`), brings Benchling Referenced Entities and bucket-optional deployments, improves image previews across many formats, and adds security updates plus an in-place network 1.0 → 2.0 migration path for stack admins.
+
+## New Quilt Platform Features
+
+### Benchling: Referenced Entities
+
+Notebook entries can now be found by searching the human-readable names of the Benchling objects they reference — for example, finding every experiment that references plasmid `QB-2743.1`. Each entry package also records the full list of referenced objects.
+
+### Benchling: Bucketless Deployments
+
+The Benchling package bucket is now optional. Without a dedicated bucket, linked-package search on entry canvases spans all of your package-view buckets via a single Iceberg query.
+
+### Quilt Connect: Sign-In from Local MCP Clients
+
+OAuth sign-in from local MCP clients such as Claude Code now works on WAF-enabled stacks — the localhost callback address previously tripped a firewall rule on the authorization page.
+
+### Safer MCP `package_create`
+
+The `package_create` tool no longer silently replaces an existing package's entire manifest. It now refuses when the package already exists — steering you to `package_patch` for incremental changes — and requires `overwrite=true` to replace it. When it does overwrite, it reports an added / removed / kept entry diff against the previous revision.
+
+### More Reliable Sign-In on Expired Sessions
+
+An expired or rejected session now reliably redirects you to sign-in instead of showing a generic error page — for example, when a server-side SSO token refresh fails. Previously only one specific error was recognized; any other cause could strand you on an error page until a manual re-login.
+
+### Iceberg Package Index in the Athena Dropdown
+
+Managed users now see the Iceberg package-index database in the Athena Queries "Database" dropdown; previously it was queryable only by its fully-qualified name.
+
+### Image Preview Improvements
+
+A broad set of thumbnail and preview improvements:
+
+- Multi-channel images render ~12–25% faster, and large floating-point multi-channel images near the memory limit (which previously failed intermittently) now render reliably.
+- A channel containing NaN or infinite pixel values no longer blanks the entire thumbnail.
+- Color CZI images stored in BGR pixel formats (e.g. `Bgr24` / `Bgr48`) now preview with correct colors.
+- Signed and wider-than-16-bit integer images (`uint32` / `uint64`, `int8`–`int64`, and 32-bit-integer color) now preview, contrast-stretched, instead of failing or rendering dark.
+- Previews are now 8-bit everywhere, producing smaller PNGs with no loss of meaningful detail.
+- The source image streams to disk during rendering instead of buffering fully in memory, lowering peak memory on large images.
+
+## Stack Admin Improvements
+
+### In-Place Network 1.0 → 2.0 Migration
+
+New tooling migrates a legacy network-1.0 stack to the 2.0 network layout in place — on the existing CloudFormation stack, with no new stack, no DNS or ARN changes, and no search reindexing. It ships transient template options plus an operator toolkit under `script/nw_migration/` (a gated changeset driver, Elasticsearch/DB operations, an expected-changes manifest generator, and a fail-closed guided runner) and a runbook at `script/nw_migration/NW_MIGRATION.md`. All options default unset, so existing builds are unchanged.
+
+### Quilt Connect Server ALB Follows the Stack Scheme
+
+The Quilt Connect ALB now follows the stack's `elb_scheme` instead of always being internet-facing. On an internal stack (`elb_scheme=internal`) the Connect ALB is now internal; public stacks keep it internet-facing.
+
+### Lower Registry Memory Use
+
+The registry now uses the **mimalloc** allocator instead of pymalloc, lowering per-worker memory and eliminating the intermittent out-of-memory worker kills that surfaced as a catalog "Unexpected Error".
+
+### Managed Roles: Many-Bucket Read Access
+
+Creating or editing managed policies and roles no longer fails once a single role spans roughly a dozen readable buckets.
+
+### Iceberg Storage Cleanup and Output
+
+Data from the obsolete pre-per-bucket global `package_*` Iceberg tables is now reclaimed by S3 lifecycle expiration, instead of relying on a synchronous Athena `DROP TABLE` that could time out on large stacks. The Iceberg Glue database name is also now exposed as the `IcebergDatabaseName` stack output.
+
+### Security Updates
+
+- **nginx**: the Amazon Linux base image was refreshed, picking up OS security patches accumulated since February.
+- **Lambdas**: Quilt lambda images and zips were refreshed to a recent `quilt` build — notably **aiohttp 3.14.1** in the `tabular_preview`, `s3hash`, and `status_reports` lambdas (upstream HTTP-parser and connector hardening), plus an AWS Lambda base-image refresh (OS security patches) in the `tabular_preview` and `indexer` images.
+
+## Other Improvements
+
+- Clicking a package-name prefix on the package listing page filters the list to that prefix again.
+- Syntax highlighting now loads language grammars on demand instead of all up front; code in an unsupported or unrecognized language is no longer highlighted.


### PR DESCRIPTION
Customer-facing release notes for **Platform Update 1.71** — a new `release-notes/1-71-0-release-notes.md`, grouped by theme (modeled on the 1.70.0 notes).

Hold for merge with / after the 1.71.0 release.

Highlights covered:
- Quilt Connect: OAuth sign-in from local MCP clients on WAF-enabled stacks; safer `package_create`
- Benchling: Referenced Entities + bucketless deployments
- Image preview improvements (multi-channel, CZI/BGR, wide-integer, memory)
- Stack admin: in-place network 1.0→2.0 migration; `mimalloc` registry; security updates (nginx, lambdas)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds customer-facing notes for Platform Update 1.71. The main changes are:

- Quilt Connect, Benchling, and image-preview updates.
- Network migration and stack administration improvements.
- Registry, nginx, and Lambda security updates.
- A combined 1.70/1.71 marketing-email variant.

<h3>Confidence Score: 4/5</h3>

The combined release document can produce a conflicting and incomplete customer-facing article.

- Two different documents present themselves as the 1.71 release notes.
- The combined document contains unresolved deployment values.
- Its marketing-email footer is included in the publishable Markdown.

release-notes/1-70+71-release-notes.md

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| release-notes/1-70+71-release-notes.md | Adds a combined release document that conflicts with the focused 1.71 notes and retains unresolved deployment values and an email footer. |
| release-notes/1-71-0-release-notes.md | Adds the focused Platform Update 1.71 release notes with the expected versioned filename. |

<sub>Reviews (1): Last reviewed commit: ["Add combined 1.70+1.71 release notes fro..."](https://github.com/quiltdata/knowledge-base/commit/2e13eba42a4bedcb03a59280f5e6f28c0c1f3769) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44786436)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->