### PR TITLE
Add article: collecting search-cluster diagnostics for Quilt support

### DIFF
--- a/howto-collect-search-cluster-diagnostics.md
+++ b/howto-collect-search-cluster-diagnostics.md
@@ -19,44 +19,51 @@ Four files describing shard layout, index sizes, disk allocation, and index sett
 - `cat_allocation.txt`
 - `settings.json`
 
+They contain index names (which mirror your registered bucket names), document counts, shard and disk statistics, and index configuration — no object contents, document data, or credentials.
+
 ## Step 1 — Find your domain and endpoint
 
 List the domains in your account (use your stack's region):
 
 ```bash
-aws opensearch list-domain-names
+aws opensearch list-domain-names --region <REGION>
 ```
 
-Your Quilt search domain's name starts with your CloudFormation stack name (e.g. `prod-qu-search-…`). Get its VPC endpoint and engine version:
+The search domain's name is derived from your CloudFormation stack name — lowercased and truncated — so a stack named `Prod-QuiltDeploymentStack` gets a domain like `prod-qu-search-<random-suffix>`. Get its VPC endpoint, engine version, and VPC:
 
 ```bash
-aws opensearch describe-domain --domain-name <DOMAIN_NAME> \
-  --query 'DomainStatus.{endpoint:Endpoints.vpc,version:EngineVersion}'
+aws opensearch describe-domain --domain-name <DOMAIN_NAME> --region <REGION> \
+  --query 'DomainStatus.{endpoint:Endpoints.vpc,version:EngineVersion,vpc:VPCOptions.VPCId}'
 ```
 
-Note both — include the engine version in what you send to support.
+Note all three — the endpoint and VPC are used below; include the engine version in what you send to support. If you run several Quilt stacks, the `vpc` value tells you which stack's VPC a domain belongs to.
 
 ## Step 2 — Get a shell inside the stack VPC
 
 The host needs two security groups from your Quilt stack:
 
 - **`…SearchClusterAccessorSecurityGroup…`** — the domain only accepts connections (port 443) from members of this group. Find it in the EC2 console by its description: *"For resources that need access to search cluster"*, or in the CloudFormation stack's Resources tab under the logical ID `SearchClusterAccessorSecurityGroup`.
-- **`…OutboundSecurityGroup…`** — general outbound access, needed to install tooling.
+- **`…OutboundSecurityGroup…`** — allows outbound HTTPS (port 443), needed to download tooling. Console description: *"Outbound HTTPS traffic to anywhere"*; logical ID `OutboundSecurityGroup`.
 
 ### Option A — an existing host in the stack VPC
 
-If you already have a bastion/EC2 instance in the Quilt stack's VPC, attach the two security groups above to it and skip to Step 3.
+If you already have a bastion/EC2 instance in the Quilt stack's VPC, attach the two security groups above to it and skip to Step 3. The instance needs `python3` and `pip3`, and its credentials (typically the instance profile) must carry the Step 3 permissions — default instance profiles usually don't.
 
 ### Option B — AWS CloudShell VPC environment
 
-1. Open **CloudShell** in the AWS console (in your stack's region) and create a new **VPC environment**.
-2. **VPC**: your Quilt stack's VPC.
-3. **Subnet**: a **private subnet with a NAT route** to the internet. Do not pick an isolated subnet (in Quilt network-2.0 deployments the domain itself lives in isolated "intra" subnets — those have no internet access, and `pip install` will hang there). The subnet does not need to be the domain's own subnet; any subnet in the VPC can reach it.
+1. Open **CloudShell** in the AWS console (in your stack's region) and create a new **VPC environment**. Creating one needs CloudShell and EC2-describe permissions in addition to Step 3. You can have at most **two** VPC environments per user, and an environment's network settings can't be edited after creation — verify the subnet (next point) before creating.
+2. **VPC**: the `vpc` value from Step 1.
+3. **Subnet**: a **private subnet with a NAT route** — its route table should have a `0.0.0.0/0` route pointing at a NAT gateway (`nat-…`). Two choices that look plausible but fail: *isolated* subnets (no internet route at all — in Quilt network-2.0 deployments the domain's own "intra" subnets are like this, and `pip install` will hang there), and *public* subnets (CloudShell VPC environments get no public IP, so an internet-gateway route gives them no internet either). The subnet does not need to be the domain's own subnet; any subnet in the VPC can reach it.
 4. **Security groups**: the two groups from above.
 
 ## Step 3 — Credentials
 
-Your shell's AWS credentials (in CloudShell, the console role you're signed in with) need the `es:ESHttp*` permission on the domain. Administrator roles typically have this.
+Your shell's AWS credentials (in CloudShell, the console role you're signed in with) need:
+
+- `es:ESHttpGet` on the domain — the diagnostic requests below are all read-only GETs
+- `es:ListDomainNames` and `es:DescribeDomain` — for Step 1
+
+Check whether your existing role already allows these before granting anything new.
 
 ## Step 4 — Collect the diagnostics
 
@@ -67,27 +74,54 @@ pip3 install --user awscurl
 export PATH="$HOME/.local/bin:$PATH"
 ```
 
-Then (fill in your endpoint and region):
+Then fill in your endpoint and region. `<VPC_ENDPOINT>` is the `endpoint` value from Step 1, which has no scheme prefix — the result should look like `ES=https://vpc-prod-qu-search-abc123.us-east-1.es.amazonaws.com`:
 
 ```bash
 ES=https://<VPC_ENDPOINT>
 REGION=<REGION>
 
-awscurl --service es --region $REGION "$ES/_cat/shards?v=true"                  > cat_shards.txt
-awscurl --service es --region $REGION "$ES/_cat/indices?v=true"                 > cat_indices.txt
-awscurl --service es --region $REGION "$ES/_cat/allocation?v=true"              > cat_allocation.txt
-awscurl --service es --region $REGION "$ES/_all/_settings?flat_settings=true"   > settings.json
+awscurl --fail-with-body --service es --region $REGION "$ES/_cat/shards?v=true"                  > cat_shards.txt
+awscurl --fail-with-body --service es --region $REGION "$ES/_cat/indices?v=true"                 > cat_indices.txt
+awscurl --fail-with-body --service es --region $REGION "$ES/_cat/allocation?v=true"              > cat_allocation.txt
+awscurl --fail-with-body --service es --region $REGION "$ES/_all/_settings?flat_settings=true"   > settings.json
 ```
 
 Use the commands exactly as written: AWS-managed domains only accept an allowlisted subset of the Elasticsearch REST API (for example, `/_all/_settings` is allowed but bare `/_settings` is rejected).
 
-## Step 5 — Send the files
+Sanity-check the results — a failed command exits with an error status, and its output file then contains the error message instead of data:
+
+```bash
+head -2 cat_shards.txt cat_indices.txt cat_allocation.txt
+head -c 100 settings.json; echo
+```
+
+The three `.txt` files should each show a column-header table (`index shard prirep state …`); `settings.json` should start with `{"<index-name>":…`. A file containing `{"Message": …}` means that request failed — see Troubleshooting.
+
+## Step 5 — Copy the files off the host
+
+CloudShell VPC environments can't use the console's upload/download menu, and their storage is **deleted when the session ends** — so move the files to S3 right away:
+
+```bash
+aws s3 cp cat_shards.txt s3://<your-bucket>/search-diagnostics/
+aws s3 cp cat_indices.txt s3://<your-bucket>/search-diagnostics/
+aws s3 cp cat_allocation.txt s3://<your-bucket>/search-diagnostics/
+aws s3 cp settings.json s3://<your-bucket>/search-diagnostics/
+```
+
+Use any bucket you can write to, then download the files from the S3 console. On an Option A host, your usual file transfer (`scp`, SSM) works too.
+
+## Step 6 — Send the files
 
 Attach the four files (plus the engine version from Step 1) to your support thread or email them to support@quilt.bio.
 
+## Cleanup
+
+- **Option B**: delete the CloudShell VPC environment when you're done — it otherwise keeps network interfaces in your VPC.
+- **Option A**: detach the two security groups from the instance; they're only needed while collecting.
+
 ## Troubleshooting
 
-- **`403`** — the credentials lack `es:ESHttp*` on the domain (Step 3), or the request isn't signed (plain `curl` won't work).
+- **`403`** — the credentials lack `es:ESHttpGet` on the domain (Step 3), or the request isn't signed (plain `curl` won't work).
 - **`401` `"Your request … is not allowed"`** — the URL path isn't on AWS's supported-operations allowlist for managed domains; use the commands exactly as given above.
 - **Connection timeout** — the host isn't in the stack VPC, or is missing the `SearchClusterAccessorSecurityGroup`.
 - **`pip install` hangs** — the subnet has no internet route; pick a NAT-routed private subnet (Option B, point 3).

--- a/howto-collect-search-cluster-diagnostics.md
+++ b/howto-collect-search-cluster-diagnostics.md
@@ -2,32 +2,37 @@
 
 ## Tags
 
-`aws`, `elasticsearch`, `opensearch`, `search`, `vpc`, `cloudshell`, `diagnostics`, `troubleshooting`
+`aws`, `elasticsearch`, `opensearch`, `search`, `vpc`, `cloudshell`, `cloudwatch`, `diagnostics`, `troubleshooting`
 
 ## Summary
 
-When you report search-related issues (slow or failing searches, incomplete results, high cluster CPU), Quilt support may ask you to collect diagnostics from your deployment's Elasticsearch/OpenSearch domain. In most Quilt deployments the domain is VPC-internal, so the diagnostics must be collected from inside the Quilt stack's VPC. This article shows how to do that with an AWS CloudShell VPC environment and a short read-only script — no software installation required.
+When you report search-related issues (slow or failing searches, incomplete results, high cluster CPU), Quilt support may ask you to collect diagnostics from your deployment's Elasticsearch/OpenSearch domain: CloudWatch performance metrics, plus cluster-state files that must be collected from inside the Quilt stack's VPC (the domain is VPC-internal in most deployments). This article shows how to do both with AWS CloudShell and a short read-only script — no software installation required.
 
 ---
 
 ## What you'll collect
 
-Four files describing shard layout, index sizes, disk allocation, and index settings:
+Performance history — one JSON file per CloudWatch metric (CPU, search/indexing latency and rates, queues, JVM pressure, storage):
+
+- `cw_<MetricName>.json` (12 files)
+
+Cluster state — four files describing shard layout, index sizes, disk allocation, and index settings:
 
 - `cat_shards.txt`
 - `cat_indices.txt`
 - `cat_allocation.txt`
 - `settings.json`
 
-They contain index names (which mirror your registered bucket names), document counts, shard and disk statistics, and index configuration — no object contents, document data, or credentials.
+The metric files contain only numbers and timestamps. The cluster-state files contain index names (which mirror your registered bucket names), document counts, shard and disk statistics, and index configuration — no object contents, document data, or credentials.
 
 ## Step 1 — Check your credentials
 
 The credentials you'll use — in CloudShell, the console role you're signed in with — need:
 
-- `es:ESHttpGet` on the domain — the diagnostic requests (Step 4) are all read-only GETs
 - `es:ListDomainNames` and `es:DescribeDomain` — for Step 2
-- write access to some S3 bucket — for copying the results out (Step 5)
+- `cloudwatch:GetMetricStatistics` — for Step 3
+- `es:ESHttpGet` on the domain — the cluster-state requests (Step 5) are all read-only GETs
+- write access to some S3 bucket — for copying the results out (Step 6)
 
 Check whether your existing role already allows these before granting anything new.
 
@@ -48,21 +53,47 @@ aws opensearch describe-domain --domain-name <DOMAIN_NAME> --region <REGION> \
 
 Note all three — the endpoint and VPC are used below; include the engine version in what you send to support. If you run several Quilt stacks, the `vpc` value tells you which stack's VPC a domain belongs to.
 
-## Step 3 — Open a shell inside the stack VPC
+## Step 3 — Export CloudWatch metrics
+
+This step needs no VPC access — run it in a standard CloudShell (or any Linux shell with the AWS CLI), **not** in the VPC environment you'll create in Step 4, which has no route to the CloudWatch API. Fill in the two variables at the top:
+
+```bash
+REGION=<REGION>
+DOMAIN=<DOMAIN_NAME>
+ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
+START=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ)
+END=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+for m in CPUUtilization SearchLatency IndexingLatency SearchRate IndexingRate \
+         JVMMemoryPressure ThreadpoolSearchQueue ThreadpoolSearchRejected \
+         ThreadpoolWriteQueue ThreadpoolWriteRejected ClusterIndexWritesBlocked FreeStorageSpace; do
+  aws cloudwatch get-metric-statistics --region $REGION --namespace AWS/ES \
+    --metric-name $m --dimensions Name=DomainName,Value=$DOMAIN Name=ClientId,Value=$ACCOUNT \
+    --start-time $START --end-time $END --period 600 --statistics Average Maximum \
+    > "cw_$m.json"
+  echo "cw_$m.json"
+done
+```
+
+This exports the last 7 days at 10-minute resolution (support may ask for a different window). Each file should contain a `Datapoints` array with several hundred entries — an empty array means a wrong `DOMAIN`, `ACCOUNT`, or region.
+
+In a standard CloudShell you can download the files directly: **Actions → Download file**. (If you run Step 6 anyway, uploading these to S3 alongside the rest also works.)
+
+## Step 4 — Open a shell inside the stack VPC
 
 The domain only accepts connections from members of one security group in your Quilt stack: `…SearchClusterAccessorSecurityGroup…`. Find it in the EC2 console by its description — *"For resources that need access to search cluster"* — or in the CloudFormation stack's Resources tab under the logical ID `SearchClusterAccessorSecurityGroup`.
 
-(CloudShell isn't mandatory: any host inside the stack VPC with that security group and the Step 1 credentials can run the Step 4 script — Step 5 and Cleanup then don't apply. The path below uses CloudShell, which works even in a VPC with no internet access.)
+(CloudShell isn't mandatory: any host inside the stack VPC with that security group and the Step 1 credentials can run the Step 5 script — Step 6 and Cleanup then don't apply. The path below uses CloudShell, which works even in a VPC with no internet access.)
 
 In **CloudShell** (in your stack's region), create a new **VPC environment**. Two constraints to know before creating: you can have at most **two** VPC environments per user, and an environment's network settings can't be changed after creation — delete and recreate instead. (Creating one also needs CloudShell and EC2-describe permissions, beyond Step 1's list.) Fill in:
 
 - **VPC**: the `vpc` value from Step 2.
-- **Subnet**: any subnet in the VPC can reach the domain. Step 5 additionally needs a route to S3 — in a Quilt-created VPC every subnet has one (S3 gateway endpoint), so pick any; in a customer-managed VPC prefer a subnet that can reach S3 through an S3 gateway endpoint, NAT, or your network's usual egress path (e.g. Transit Gateway).
+- **Subnet**: any subnet in the VPC can reach the domain. Step 6 additionally needs a route to S3 — in a Quilt-created VPC every subnet has one (S3 gateway endpoint), so pick any; in a customer-managed VPC prefer a subnet that can reach S3 through an S3 gateway endpoint, NAT, or your network's usual egress path (e.g. Transit Gateway).
 - **Security group**: the one from above.
 
 Provisioning takes a minute or two; you're ready when the new environment opens with a shell prompt.
 
-## Step 4 — Collect the diagnostics
+## Step 5 — Collect the cluster state
 
 Requests to the domain must be SigV4-signed; the script below signs them with your session's credentials using CloudShell's preinstalled Python and boto3. The request paths are fixed: AWS-managed domains only accept an allowlisted subset of the Elasticsearch REST API (for example, `/_all/_settings` is allowed but bare `/_settings` is rejected).
 
@@ -106,7 +137,7 @@ settings.json HTTP 200
 
 Any other status means that request failed and its file contains the error message instead of data — see Troubleshooting.
 
-## Step 5 — Copy the files out
+## Step 6 — Copy the files out
 
 CloudShell VPC environments can't use the console's upload/download menu, and their storage is **deleted when the session ends** — so move the files to S3 right away:
 
@@ -119,9 +150,9 @@ aws s3 cp settings.json s3://<your-bucket>/search-diagnostics/
 
 Use any bucket you can write to, then download the files from the S3 console.
 
-## Step 6 — Send the files
+## Step 7 — Send the files
 
-Attach the four files (plus the engine version from Step 2) to your support thread or email them to support@quilt.bio.
+Attach everything — the `cw_*.json` metric exports, the four cluster-state files, and the engine version from Step 2 — to your support thread or email them to support@quilt.bio.
 
 ## Cleanup
 
@@ -132,4 +163,5 @@ Delete the CloudShell VPC environment when you're done — it otherwise keeps ne
 - **`HTTP 403`** — the credentials lack `es:ESHttpGet` on the domain (Step 1).
 - **`HTTP 401` with `"Your request … is not allowed"`** — the URL path isn't on AWS's supported-operations allowlist for managed domains; use the script exactly as given above.
 - **The script hangs, then times out** — the environment isn't in the stack VPC, or is missing the `SearchClusterAccessorSecurityGroup`.
-- **`aws s3 cp` hangs or fails** — the subnet has no route to S3; recreate the environment in a subnet that has one (see the subnet guidance in Step 3).
+- **`aws s3 cp` hangs or fails** — the subnet has no route to S3; recreate the environment in a subnet that has one (see the subnet guidance in Step 4).
+- **A `cw_*.json` file has an empty `Datapoints` array** — wrong `DOMAIN`, `ACCOUNT`, or region in the Step 3 variables.

--- a/howto-collect-search-cluster-diagnostics.md
+++ b/howto-collect-search-cluster-diagnostics.md
@@ -14,7 +14,7 @@ When you report search-related issues (slow or failing searches, incomplete resu
 
 You'll work in two shells: a **standard CloudShell** for the performance metrics (Step 3), and a **CloudShell VPC environment** for the cluster state (Steps 4–6).
 
-Performance history — one JSON file per CloudWatch metric (CPU, search/indexing latency and rates, queues, JVM pressure, storage):
+Performance history — one JSON file per CloudWatch metric (CPU, search/indexing latency and rates, queues and rejections, JVM pressure, storage):
 
 - `cw_<MetricName>.json` (12 files)
 
@@ -27,7 +27,7 @@ Cluster state — four files describing shard layout, index sizes, disk allocati
 
 Plus one line of text: the domain's engine version (from Step 2).
 
-Nothing here contains object data or credentials; index names in the cluster-state files mirror your registered bucket names.
+The files disclose your registered bucket names (as index names in the cluster-state files), but no object contents, document data, or credentials.
 
 ## Step 1 — Check your credentials
 
@@ -49,7 +49,7 @@ List the domains in your account (use your stack's region):
 aws opensearch list-domain-names --region <REGION>
 ```
 
-The Quilt search domain's name resembles your stack or deployment name, possibly lowercased, truncated, and suffixed — e.g. a stack named `Prod-QuiltDeploymentStack` gets a domain like `prod-qu-search-<random-suffix>`. Get its VPC endpoint, engine version, and VPC:
+The Quilt search domain's name resembles your stack or deployment name — sometimes unchanged, sometimes lowercased, truncated, and suffixed (a stack named `Prod-QuiltDeploymentStack` gets a domain like `prod-qu-search-<random-suffix>`). Get its VPC endpoint, engine version, and VPC:
 
 ```bash
 aws opensearch describe-domain --domain-name <DOMAIN_NAME> --region <REGION> \
@@ -58,7 +58,7 @@ aws opensearch describe-domain --domain-name <DOMAIN_NAME> --region <REGION> \
 
 Note all three — the endpoint and VPC are used below; include the engine version in what you send to support. If you run several Quilt stacks, the `vpc` value tells you which stack's VPC a domain belongs to.
 
-(A null `endpoint` means the domain has a public endpoint instead — `DomainStatus.Endpoint`; then skip Step 4 and run the Step 5 script from any shell.)
+(A null `endpoint` means the domain has a public endpoint instead — `DomainStatus.Endpoint`. Then skip Step 4, run the Step 5 script from any shell with that endpoint as `HOST`, and skip Step 6 — the files land wherever you ran the script.)
 
 ## Step 3 — Export CloudWatch metrics
 
@@ -88,9 +88,9 @@ In a standard CloudShell you can download the files directly: **Actions → Down
 
 ## Step 4 — Open a shell inside the stack VPC
 
-The domain only accepts connections from members of one security group in your Quilt deployment. Find it in the EC2 console by its description — *"For resources that need access to search cluster"* — or by name: it contains `search-accessor` or `SearchClusterAccessorSecurityGroup`.
+The domain only accepts connections from members of one security group in your Quilt deployment. Find it in the EC2 console by its description — *"For resources that need access to search cluster"* — or by name: depending on how your deployment was created it contains `search-accessor` or `SearchClusterAccessorSecurityGroup`.
 
-In **CloudShell** (in your stack's region), create a new **VPC environment**. Before creating, know: at most **two** VPC environments per user, and network settings are fixed at creation — delete and recreate to change them. Fill in:
+In **CloudShell** (in your stack's region), create a new **VPC environment** ([AWS walkthrough](https://docs.aws.amazon.com/cloudshell/latest/userguide/creating-vpc-environment.html)). Before creating, know: at most **two** VPC environments per user (delete one if you're at the limit), and network settings are fixed at creation — delete and recreate to change them. Fill in:
 
 - **VPC**: the `vpc` value from Step 2.
 - **Subnet**: any subnet reaches the domain, but Step 6 needs an S3 route from it — an S3 gateway endpoint in the subnet's route table, NAT, or your usual egress path (e.g. Transit Gateway). In Quilt-created VPCs every subnet typically qualifies.
@@ -100,9 +100,9 @@ Provisioning takes a minute or two; you're ready when the new environment opens 
 
 ## Step 5 — Collect the cluster state
 
-Requests to the domain must be SigV4-signed; the script below signs them with your session's credentials using CloudShell's preinstalled Python and boto3. The request paths are fixed: AWS-managed domains accept only an allowlisted subset of the Elasticsearch REST API.
+Back in the **VPC environment** from Step 4: requests to the domain must be SigV4-signed, and the script below signs them with your session's credentials using CloudShell's preinstalled Python and boto3. The request paths are fixed — AWS-managed domains accept only an allowlisted subset of the domain's REST API.
 
-Fill in the two placeholders — `<VPC_ENDPOINT>` is the `endpoint` value from Step 2, pasted as-is (no `https://` prefix); `<REGION>` is your stack's region, as in Step 2 — then paste the whole block:
+Fill in the two placeholders — `<VPC_ENDPOINT>` is the `endpoint` value from Step 2 (no `https://` prefix); `<REGION>` as before — then paste the whole block:
 
 ```bash
 python3 << 'EOF'
@@ -147,10 +147,10 @@ Any other status means that request failed and its file contains the error messa
 CloudShell VPC environments can't use the console's upload/download menu, and their storage is **deleted when the session ends** — so move the files to S3 right away:
 
 ```bash
-aws s3 cp cat_shards.txt s3://<YOUR_BUCKET>/search-diagnostics/
-aws s3 cp cat_indices.txt s3://<YOUR_BUCKET>/search-diagnostics/
-aws s3 cp cat_allocation.txt s3://<YOUR_BUCKET>/search-diagnostics/
-aws s3 cp settings.json s3://<YOUR_BUCKET>/search-diagnostics/
+aws s3 cp cat_shards.txt s3://<BUCKET>/search-diagnostics/
+aws s3 cp cat_indices.txt s3://<BUCKET>/search-diagnostics/
+aws s3 cp cat_allocation.txt s3://<BUCKET>/search-diagnostics/
+aws s3 cp settings.json s3://<BUCKET>/search-diagnostics/
 ```
 
 Use any bucket you can write to, then download the files from the S3 console.
@@ -166,7 +166,7 @@ Delete the CloudShell VPC environment when you're done — it otherwise keeps ne
 ## Troubleshooting
 
 - **A `cw_*.json` file has an empty `Datapoints` array** (Step 3) — wrong `DOMAIN`, `ACCOUNT`, or region in the variables.
-- **The script hangs, then times out** (Step 5) — the environment isn't in the stack VPC, or is missing the `SearchClusterAccessorSecurityGroup`.
+- **The script hangs, then times out** (Step 5) — the environment isn't in the stack VPC, or is missing the accessor security group from Step 4.
 - **`HTTP 403`** (Step 5) — the credentials lack `es:ESHttpGet` on the domain (Step 1).
 - **`HTTP 401` with `"Your request … is not allowed"`** (Step 5) — the URL path isn't on AWS's supported-operations allowlist for managed domains; use the script exactly as given above.
 - **`aws s3 cp` hangs or fails** (Step 6) — the subnet has no route to S3; recreate the environment in a subnet that has one (see the subnet guidance in Step 4).

--- a/howto-collect-search-cluster-diagnostics.md
+++ b/howto-collect-search-cluster-diagnostics.md
@@ -1,0 +1,93 @@
+# How do I collect search-cluster diagnostics for Quilt support?
+
+## Tags
+
+`aws`, `elasticsearch`, `opensearch`, `search`, `vpc`, `cloudshell`, `diagnostics`, `troubleshooting`
+
+## Summary
+
+When you report search-related issues (slow or failing searches, incomplete results, high cluster CPU), Quilt support may ask you to collect diagnostics from your deployment's Elasticsearch/OpenSearch domain. In most Quilt deployments the domain is VPC-internal, so the four read-only diagnostic commands must run from a host inside the Quilt stack's VPC — an existing instance, or an AWS CloudShell VPC environment — using SigV4-signed requests via `awscurl`.
+
+---
+
+## What you'll collect
+
+Four files describing shard layout, index sizes, disk allocation, and index settings:
+
+- `cat_shards.txt`
+- `cat_indices.txt`
+- `cat_allocation.txt`
+- `settings.json`
+
+## Step 1 — Find your domain and endpoint
+
+List the domains in your account (use your stack's region):
+
+```bash
+aws opensearch list-domain-names
+```
+
+Your Quilt search domain's name starts with your CloudFormation stack name (e.g. `prod-qu-search-…`). Get its VPC endpoint and engine version:
+
+```bash
+aws opensearch describe-domain --domain-name <DOMAIN_NAME> \
+  --query 'DomainStatus.{endpoint:Endpoints.vpc,version:EngineVersion}'
+```
+
+Note both — include the engine version in what you send to support.
+
+## Step 2 — Get a shell inside the stack VPC
+
+The host needs two security groups from your Quilt stack:
+
+- **`…SearchClusterAccessorSecurityGroup…`** — the domain only accepts connections (port 443) from members of this group. Find it in the EC2 console by its description: *"For resources that need access to search cluster"*, or in the CloudFormation stack's Resources tab under the logical ID `SearchClusterAccessorSecurityGroup`.
+- **`…OutboundSecurityGroup…`** — general outbound access, needed to install tooling.
+
+### Option A — an existing host in the stack VPC
+
+If you already have a bastion/EC2 instance in the Quilt stack's VPC, attach the two security groups above to it and skip to Step 3.
+
+### Option B — AWS CloudShell VPC environment
+
+1. Open **CloudShell** in the AWS console (in your stack's region) and create a new **VPC environment**.
+2. **VPC**: your Quilt stack's VPC.
+3. **Subnet**: a **private subnet with a NAT route** to the internet. Do not pick an isolated subnet (in Quilt network-2.0 deployments the domain itself lives in isolated "intra" subnets — those have no internet access, and `pip install` will hang there). The subnet does not need to be the domain's own subnet; any subnet in the VPC can reach it.
+4. **Security groups**: the two groups from above.
+
+## Step 3 — Credentials
+
+Your shell's AWS credentials (in CloudShell, the console role you're signed in with) need the `es:ESHttp*` permission on the domain. Administrator roles typically have this.
+
+## Step 4 — Collect the diagnostics
+
+Requests to the domain must be SigV4-signed; [`awscurl`](https://github.com/okigan/awscurl) handles that:
+
+```bash
+pip3 install --user awscurl
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+Then (fill in your endpoint and region):
+
+```bash
+ES=https://<VPC_ENDPOINT>
+REGION=<REGION>
+
+awscurl --service es --region $REGION "$ES/_cat/shards?v=true"                  > cat_shards.txt
+awscurl --service es --region $REGION "$ES/_cat/indices?v=true"                 > cat_indices.txt
+awscurl --service es --region $REGION "$ES/_cat/allocation?v=true"              > cat_allocation.txt
+awscurl --service es --region $REGION "$ES/_all/_settings?flat_settings=true"   > settings.json
+```
+
+Use the commands exactly as written: AWS-managed domains only accept an allowlisted subset of the Elasticsearch REST API (for example, `/_all/_settings` is allowed but bare `/_settings` is rejected).
+
+## Step 5 — Send the files
+
+Attach the four files (plus the engine version from Step 1) to your support thread or email them to support@quilt.bio.
+
+## Troubleshooting
+
+- **`403`** — the credentials lack `es:ESHttp*` on the domain (Step 3), or the request isn't signed (plain `curl` won't work).
+- **`401` `"Your request … is not allowed"`** — the URL path isn't on AWS's supported-operations allowlist for managed domains; use the commands exactly as given above.
+- **Connection timeout** — the host isn't in the stack VPC, or is missing the `SearchClusterAccessorSecurityGroup`.
+- **`pip install` hangs** — the subnet has no internet route; pick a NAT-routed private subnet (Option B, point 3).

--- a/howto-collect-search-cluster-diagnostics.md
+++ b/howto-collect-search-cluster-diagnostics.md
@@ -49,7 +49,7 @@ List the domains in your account (use your stack's region):
 aws opensearch list-domain-names --region <REGION>
 ```
 
-The search domain's name is derived from your CloudFormation stack name — lowercased and truncated — so a stack named `Prod-QuiltDeploymentStack` gets a domain like `prod-qu-search-<random-suffix>`. Get its VPC endpoint, engine version, and VPC:
+The Quilt search domain's name resembles your stack or deployment name, possibly lowercased, truncated, and suffixed — e.g. a stack named `Prod-QuiltDeploymentStack` gets a domain like `prod-qu-search-<random-suffix>`. Get its VPC endpoint, engine version, and VPC:
 
 ```bash
 aws opensearch describe-domain --domain-name <DOMAIN_NAME> --region <REGION> \
@@ -88,12 +88,12 @@ In a standard CloudShell you can download the files directly: **Actions → Down
 
 ## Step 4 — Open a shell inside the stack VPC
 
-The domain only accepts connections from members of one security group in your Quilt stack: `…SearchClusterAccessorSecurityGroup…`. Find it in the EC2 console by its description — *"For resources that need access to search cluster"* — or in the CloudFormation stack's Resources tab under the logical ID `SearchClusterAccessorSecurityGroup`.
+The domain only accepts connections from members of one security group in your Quilt deployment. Find it in the EC2 console by its description — *"For resources that need access to search cluster"* — or by name: it contains `search-accessor` or `SearchClusterAccessorSecurityGroup`.
 
 In **CloudShell** (in your stack's region), create a new **VPC environment**. Before creating, know: at most **two** VPC environments per user, and network settings are fixed at creation — delete and recreate to change them. Fill in:
 
 - **VPC**: the `vpc` value from Step 2.
-- **Subnet**: any subnet reaches the domain, but Step 6 needs an S3 route from it. Quilt-created VPCs: every subnet has one (S3 gateway endpoint) — pick any. Customer-managed VPCs: pick a subnet with an S3 gateway endpoint, NAT, or your usual egress path (e.g. Transit Gateway).
+- **Subnet**: any subnet reaches the domain, but Step 6 needs an S3 route from it — an S3 gateway endpoint in the subnet's route table, NAT, or your usual egress path (e.g. Transit Gateway). In Quilt-created VPCs every subnet typically qualifies.
 - **Security group**: the one from above.
 
 Provisioning takes a minute or two; you're ready when the new environment opens with a shell prompt.

--- a/howto-collect-search-cluster-diagnostics.md
+++ b/howto-collect-search-cluster-diagnostics.md
@@ -12,6 +12,8 @@ When you report search-related issues (slow or failing searches, incomplete resu
 
 ## What you'll collect
 
+You'll work in two shells: a **standard CloudShell** for the performance metrics (Step 3), and a **CloudShell VPC environment** for the cluster state (Steps 4–6).
+
 Performance history — one JSON file per CloudWatch metric (CPU, search/indexing latency and rates, queues, JVM pressure, storage):
 
 - `cw_<MetricName>.json` (12 files)
@@ -23,6 +25,8 @@ Cluster state — four files describing shard layout, index sizes, disk allocati
 - `cat_allocation.txt`
 - `settings.json`
 
+Plus one line of text: the domain's engine version (from Step 2).
+
 The metric files contain only numbers and timestamps. The cluster-state files contain index names (which mirror your registered bucket names), document counts, shard and disk statistics, and index configuration — no object contents, document data, or credentials.
 
 ## Step 1 — Check your credentials
@@ -31,6 +35,7 @@ The credentials you'll use — in CloudShell, the console role you're signed in 
 
 - `es:ListDomainNames` and `es:DescribeDomain` — for Step 2
 - `cloudwatch:GetMetricStatistics` — for Step 3
+- permission to create and use CloudShell VPC environments ([AWS's required IAM permissions](https://docs.aws.amazon.com/cloudshell/latest/userguide/sec-auth-with-identities.html)) — for Step 4
 - `es:ESHttpGet` on the domain — the cluster-state requests (Step 5) are all read-only GETs
 - write access to some S3 bucket — for copying the results out (Step 6)
 
@@ -52,6 +57,8 @@ aws opensearch describe-domain --domain-name <DOMAIN_NAME> --region <REGION> \
 ```
 
 Note all three — the endpoint and VPC are used below; include the engine version in what you send to support. If you run several Quilt stacks, the `vpc` value tells you which stack's VPC a domain belongs to.
+
+(If `endpoint` comes back null, your domain has a public endpoint instead — check `--query 'DomainStatus.Endpoint'`. In that case skip Step 4 entirely and run the Step 5 script from any shell, using that endpoint as `HOST`.)
 
 ## Step 3 — Export CloudWatch metrics
 
@@ -77,15 +84,15 @@ done
 
 This exports the last 7 days at 10-minute resolution (support may ask for a different window). Each file should contain a `Datapoints` array with several hundred entries — an empty array means a wrong `DOMAIN`, `ACCOUNT`, or region.
 
-In a standard CloudShell you can download the files directly: **Actions → Download file**. (If you run Step 6 anyway, uploading these to S3 alongside the rest also works.)
+In a standard CloudShell you can download the files directly: **Actions → Download file**. (Or `aws s3 cp` them to the same bucket you'll use in Step 6.)
 
 ## Step 4 — Open a shell inside the stack VPC
 
 The domain only accepts connections from members of one security group in your Quilt stack: `…SearchClusterAccessorSecurityGroup…`. Find it in the EC2 console by its description — *"For resources that need access to search cluster"* — or in the CloudFormation stack's Resources tab under the logical ID `SearchClusterAccessorSecurityGroup`.
 
-(CloudShell isn't mandatory: any host inside the stack VPC with that security group and the Step 1 credentials can run the Step 5 script — Step 6 and Cleanup then don't apply. The path below uses CloudShell, which works even in a VPC with no internet access.)
+(CloudShell isn't mandatory: any host inside the stack VPC with that security group, the Step 1 credentials, and python3 + boto3 can run the Step 5 script — then copy the files off it however you normally would; Step 6 and Cleanup are CloudShell-specific. The path below uses CloudShell, which works even in a VPC with no internet access.)
 
-In **CloudShell** (in your stack's region), create a new **VPC environment**. Two constraints to know before creating: you can have at most **two** VPC environments per user, and an environment's network settings can't be changed after creation — delete and recreate instead. (Creating one also needs CloudShell and EC2-describe permissions, beyond Step 1's list.) Fill in:
+In **CloudShell** (in your stack's region), create a new **VPC environment**. Two constraints to know before creating: you can have at most **two** VPC environments per user, and an environment's network settings can't be changed after creation — delete and recreate instead. Fill in:
 
 - **VPC**: the `vpc` value from Step 2.
 - **Subnet**: any subnet in the VPC can reach the domain. Step 6 additionally needs a route to S3 — in a Quilt-created VPC every subnet has one (S3 gateway endpoint), so pick any; in a customer-managed VPC prefer a subnet that can reach S3 through an S3 gateway endpoint, NAT, or your network's usual egress path (e.g. Transit Gateway).
@@ -137,15 +144,15 @@ settings.json HTTP 200
 
 Any other status means that request failed and its file contains the error message instead of data — see Troubleshooting.
 
-## Step 6 — Copy the files out
+## Step 6 — Copy the cluster-state files out
 
 CloudShell VPC environments can't use the console's upload/download menu, and their storage is **deleted when the session ends** — so move the files to S3 right away:
 
 ```bash
-aws s3 cp cat_shards.txt s3://<your-bucket>/search-diagnostics/
-aws s3 cp cat_indices.txt s3://<your-bucket>/search-diagnostics/
-aws s3 cp cat_allocation.txt s3://<your-bucket>/search-diagnostics/
-aws s3 cp settings.json s3://<your-bucket>/search-diagnostics/
+aws s3 cp cat_shards.txt s3://<YOUR_BUCKET>/search-diagnostics/
+aws s3 cp cat_indices.txt s3://<YOUR_BUCKET>/search-diagnostics/
+aws s3 cp cat_allocation.txt s3://<YOUR_BUCKET>/search-diagnostics/
+aws s3 cp settings.json s3://<YOUR_BUCKET>/search-diagnostics/
 ```
 
 Use any bucket you can write to, then download the files from the S3 console.
@@ -160,8 +167,8 @@ Delete the CloudShell VPC environment when you're done — it otherwise keeps ne
 
 ## Troubleshooting
 
-- **`HTTP 403`** — the credentials lack `es:ESHttpGet` on the domain (Step 1).
-- **`HTTP 401` with `"Your request … is not allowed"`** — the URL path isn't on AWS's supported-operations allowlist for managed domains; use the script exactly as given above.
-- **The script hangs, then times out** — the environment isn't in the stack VPC, or is missing the `SearchClusterAccessorSecurityGroup`.
-- **`aws s3 cp` hangs or fails** — the subnet has no route to S3; recreate the environment in a subnet that has one (see the subnet guidance in Step 4).
-- **A `cw_*.json` file has an empty `Datapoints` array** — wrong `DOMAIN`, `ACCOUNT`, or region in the Step 3 variables.
+- **A `cw_*.json` file has an empty `Datapoints` array** (Step 3) — wrong `DOMAIN`, `ACCOUNT`, or region in the variables.
+- **The script hangs, then times out** (Step 5) — the environment isn't in the stack VPC, or is missing the `SearchClusterAccessorSecurityGroup`.
+- **`HTTP 403`** (Step 5) — the credentials lack `es:ESHttpGet` on the domain (Step 1).
+- **`HTTP 401` with `"Your request … is not allowed"`** (Step 5) — the URL path isn't on AWS's supported-operations allowlist for managed domains; use the script exactly as given above.
+- **`aws s3 cp` hangs or fails** (Step 6) — the subnet has no route to S3; recreate the environment in a subnet that has one (see the subnet guidance in Step 4).

--- a/howto-collect-search-cluster-diagnostics.md
+++ b/howto-collect-search-cluster-diagnostics.md
@@ -6,7 +6,7 @@
 
 ## Summary
 
-When you report search-related issues (slow or failing searches, incomplete results, high cluster CPU), Quilt support may ask you to collect diagnostics from your deployment's Elasticsearch/OpenSearch domain. In most Quilt deployments the domain is VPC-internal, so the four read-only diagnostic commands must run from a host inside the Quilt stack's VPC — an existing instance, or an AWS CloudShell VPC environment — using SigV4-signed requests via `awscurl`.
+When you report search-related issues (slow or failing searches, incomplete results, high cluster CPU), Quilt support may ask you to collect diagnostics from your deployment's Elasticsearch/OpenSearch domain. In most Quilt deployments the domain is VPC-internal, so the diagnostics must be collected from inside the Quilt stack's VPC. This article shows how to do that with an AWS CloudShell VPC environment and a short read-only script — no software installation required.
 
 ---
 
@@ -21,7 +21,17 @@ Four files describing shard layout, index sizes, disk allocation, and index sett
 
 They contain index names (which mirror your registered bucket names), document counts, shard and disk statistics, and index configuration — no object contents, document data, or credentials.
 
-## Step 1 — Find your domain and endpoint
+## Step 1 — Check your credentials
+
+The credentials you'll use — in CloudShell, the console role you're signed in with — need:
+
+- `es:ESHttpGet` on the domain — the diagnostic requests (Step 4) are all read-only GETs
+- `es:ListDomainNames` and `es:DescribeDomain` — for Step 2
+- write access to some S3 bucket — for copying the results out (Step 5)
+
+Check whether your existing role already allows these before granting anything new.
+
+## Step 2 — Find your domain and endpoint
 
 List the domains in your account (use your stack's region):
 
@@ -38,66 +48,65 @@ aws opensearch describe-domain --domain-name <DOMAIN_NAME> --region <REGION> \
 
 Note all three — the endpoint and VPC are used below; include the engine version in what you send to support. If you run several Quilt stacks, the `vpc` value tells you which stack's VPC a domain belongs to.
 
-## Step 2 — Get a shell inside the stack VPC
+## Step 3 — Open a shell inside the stack VPC
 
-The host needs two security groups from your Quilt stack:
+The domain only accepts connections from members of one security group in your Quilt stack: `…SearchClusterAccessorSecurityGroup…`. Find it in the EC2 console by its description — *"For resources that need access to search cluster"* — or in the CloudFormation stack's Resources tab under the logical ID `SearchClusterAccessorSecurityGroup`.
 
-- **`…SearchClusterAccessorSecurityGroup…`** — the domain only accepts connections (port 443) from members of this group. Find it in the EC2 console by its description: *"For resources that need access to search cluster"*, or in the CloudFormation stack's Resources tab under the logical ID `SearchClusterAccessorSecurityGroup`.
-- **`…OutboundSecurityGroup…`** — allows outbound HTTPS (port 443), needed to download tooling. Console description: *"Outbound HTTPS traffic to anywhere"*; logical ID `OutboundSecurityGroup`.
+(CloudShell isn't mandatory: any host inside the stack VPC with that security group and the Step 1 credentials can run the Step 4 script — Step 5 and Cleanup then don't apply. The path below uses CloudShell, which works even in a VPC with no internet access.)
 
-### Option A — an existing host in the stack VPC
+In **CloudShell** (in your stack's region), create a new **VPC environment**. Two constraints to know before creating: you can have at most **two** VPC environments per user, and an environment's network settings can't be changed after creation — delete and recreate instead. (Creating one also needs CloudShell and EC2-describe permissions, beyond Step 1's list.) Fill in:
 
-If you already have a bastion/EC2 instance in the Quilt stack's VPC, attach the two security groups above to it and skip to Step 3. The instance needs `python3` and `pip3`, and its credentials (typically the instance profile) must carry the Step 3 permissions — default instance profiles usually don't.
+- **VPC**: the `vpc` value from Step 2.
+- **Subnet**: any subnet in the VPC can reach the domain. Step 5 additionally needs a route to S3 — in a Quilt-created VPC every subnet has one (S3 gateway endpoint), so pick any; in a customer-managed VPC prefer a subnet that can reach S3 through an S3 gateway endpoint, NAT, or your network's usual egress path (e.g. Transit Gateway).
+- **Security group**: the one from above.
 
-### Option B — AWS CloudShell VPC environment
-
-1. Open **CloudShell** in the AWS console (in your stack's region) and create a new **VPC environment**. Creating one needs CloudShell and EC2-describe permissions in addition to Step 3. You can have at most **two** VPC environments per user, and an environment's network settings can't be edited after creation — verify the subnet (next point) before creating.
-2. **VPC**: the `vpc` value from Step 1.
-3. **Subnet**: a **private subnet with a NAT route** — its route table should have a `0.0.0.0/0` route pointing at a NAT gateway (`nat-…`). Two choices that look plausible but fail: *isolated* subnets (no internet route at all — in Quilt network-2.0 deployments the domain's own "intra" subnets are like this, and `pip install` will hang there), and *public* subnets (CloudShell VPC environments get no public IP, so an internet-gateway route gives them no internet either). The subnet does not need to be the domain's own subnet; any subnet in the VPC can reach it.
-4. **Security groups**: the two groups from above.
-
-## Step 3 — Credentials
-
-Your shell's AWS credentials (in CloudShell, the console role you're signed in with) need:
-
-- `es:ESHttpGet` on the domain — the diagnostic requests below are all read-only GETs
-- `es:ListDomainNames` and `es:DescribeDomain` — for Step 1
-
-Check whether your existing role already allows these before granting anything new.
+Provisioning takes a minute or two; you're ready when the new environment opens with a shell prompt.
 
 ## Step 4 — Collect the diagnostics
 
-Requests to the domain must be SigV4-signed; [`awscurl`](https://github.com/okigan/awscurl) handles that:
+Requests to the domain must be SigV4-signed; the script below signs them with your session's credentials using CloudShell's preinstalled Python and boto3. The request paths are fixed: AWS-managed domains only accept an allowlisted subset of the Elasticsearch REST API (for example, `/_all/_settings` is allowed but bare `/_settings` is rejected).
+
+Fill in the two placeholders — `<VPC_ENDPOINT>` is the `endpoint` value from Step 2, pasted as-is (no `https://` prefix); `<REGION>` is your stack's region, as in Step 2 — then paste the whole block:
 
 ```bash
-pip3 install --user awscurl
-export PATH="$HOME/.local/bin:$PATH"
+python3 << 'EOF'
+import boto3, urllib3
+from botocore.auth import SigV4Auth
+from botocore.awsrequest import AWSRequest
+
+HOST = "<VPC_ENDPOINT>"
+REGION = "<REGION>"
+
+FILES = {
+    "cat_shards.txt": "/_cat/shards?v=true",
+    "cat_indices.txt": "/_cat/indices?v=true",
+    "cat_allocation.txt": "/_cat/allocation?v=true",
+    "settings.json": "/_all/_settings?flat_settings=true",
+}
+creds = boto3.Session().get_credentials().get_frozen_credentials()
+http = urllib3.PoolManager()
+for fname, path in FILES.items():
+    url = "https://" + HOST + path
+    req = AWSRequest(method="GET", url=url)
+    SigV4Auth(creds, "es", REGION).add_auth(req)
+    r = http.request("GET", url, headers=dict(req.headers))
+    open(fname, "wb").write(r.data)
+    print(fname, "HTTP", r.status)
+EOF
 ```
 
-Then fill in your endpoint and region. `<VPC_ENDPOINT>` is the `endpoint` value from Step 1, which has no scheme prefix — the result should look like `ES=https://vpc-prod-qu-search-abc123.us-east-1.es.amazonaws.com`:
+Every line of output should end in `HTTP 200`:
 
-```bash
-ES=https://<VPC_ENDPOINT>
-REGION=<REGION>
-
-awscurl --fail-with-body --service es --region $REGION "$ES/_cat/shards?v=true"                  > cat_shards.txt
-awscurl --fail-with-body --service es --region $REGION "$ES/_cat/indices?v=true"                 > cat_indices.txt
-awscurl --fail-with-body --service es --region $REGION "$ES/_cat/allocation?v=true"              > cat_allocation.txt
-awscurl --fail-with-body --service es --region $REGION "$ES/_all/_settings?flat_settings=true"   > settings.json
+```text
+cat_shards.txt HTTP 200
+cat_indices.txt HTTP 200
+cat_allocation.txt HTTP 200
+settings.json HTTP 200
 ```
 
-Use the commands exactly as written: AWS-managed domains only accept an allowlisted subset of the Elasticsearch REST API (for example, `/_all/_settings` is allowed but bare `/_settings` is rejected).
+Any other status means that request failed and its file contains the error message instead of data — see Troubleshooting.
 
-Sanity-check the results — a failed command exits with an error status, and its output file then contains the error message instead of data:
-
-```bash
-head -2 cat_shards.txt cat_indices.txt cat_allocation.txt
-head -c 100 settings.json; echo
-```
-
-The three `.txt` files should each show a column-header table (`index shard prirep state …`); `settings.json` should start with `{"<index-name>":…`. A file containing `{"Message": …}` means that request failed — see Troubleshooting.
-
-## Step 5 — Copy the files off the host
+## Step 5 — Copy the files out
 
 CloudShell VPC environments can't use the console's upload/download menu, and their storage is **deleted when the session ends** — so move the files to S3 right away:
 
@@ -108,20 +117,19 @@ aws s3 cp cat_allocation.txt s3://<your-bucket>/search-diagnostics/
 aws s3 cp settings.json s3://<your-bucket>/search-diagnostics/
 ```
 
-Use any bucket you can write to, then download the files from the S3 console. On an Option A host, your usual file transfer (`scp`, SSM) works too.
+Use any bucket you can write to, then download the files from the S3 console.
 
 ## Step 6 — Send the files
 
-Attach the four files (plus the engine version from Step 1) to your support thread or email them to support@quilt.bio.
+Attach the four files (plus the engine version from Step 2) to your support thread or email them to support@quilt.bio.
 
 ## Cleanup
 
-- **Option B**: delete the CloudShell VPC environment when you're done — it otherwise keeps network interfaces in your VPC.
-- **Option A**: detach the two security groups from the instance; they're only needed while collecting.
+Delete the CloudShell VPC environment when you're done — it otherwise keeps network interfaces in your VPC.
 
 ## Troubleshooting
 
-- **`403`** — the credentials lack `es:ESHttpGet` on the domain (Step 3), or the request isn't signed (plain `curl` won't work).
-- **`401` `"Your request … is not allowed"`** — the URL path isn't on AWS's supported-operations allowlist for managed domains; use the commands exactly as given above.
-- **Connection timeout** — the host isn't in the stack VPC, or is missing the `SearchClusterAccessorSecurityGroup`.
-- **`pip install` hangs** — the subnet has no internet route; pick a NAT-routed private subnet (Option B, point 3).
+- **`HTTP 403`** — the credentials lack `es:ESHttpGet` on the domain (Step 1).
+- **`HTTP 401` with `"Your request … is not allowed"`** — the URL path isn't on AWS's supported-operations allowlist for managed domains; use the script exactly as given above.
+- **The script hangs, then times out** — the environment isn't in the stack VPC, or is missing the `SearchClusterAccessorSecurityGroup`.
+- **`aws s3 cp` hangs or fails** — the subnet has no route to S3; recreate the environment in a subnet that has one (see the subnet guidance in Step 3).

--- a/howto-collect-search-cluster-diagnostics.md
+++ b/howto-collect-search-cluster-diagnostics.md
@@ -62,14 +62,14 @@ Note all three — the endpoint and VPC are used below; include the engine versi
 
 ## Step 3 — Export CloudWatch metrics
 
-This step needs no VPC access — run it in a standard CloudShell (or any Linux shell with the AWS CLI), **not** in the VPC environment you'll create in Step 4, which has no route to the CloudWatch API. Fill in the two variables at the top:
+This step needs no VPC access — run it in a standard CloudShell (or any shell with the AWS CLI; Linux and macOS both work), **not** in the VPC environment you'll create in Step 4, which has no route to the CloudWatch API. Fill in the two variables at the top:
 
 ```bash
 REGION=<REGION>
 DOMAIN=<DOMAIN_NAME>
 ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
-START=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ)
-END=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+START=$(($(date +%s) - 7*86400))
+END=$(date +%s)
 
 for m in CPUUtilization SearchLatency IndexingLatency SearchRate IndexingRate \
          JVMMemoryPressure ThreadpoolSearchQueue ThreadpoolSearchRejected \

--- a/howto-collect-search-cluster-diagnostics.md
+++ b/howto-collect-search-cluster-diagnostics.md
@@ -6,7 +6,7 @@
 
 ## Summary
 
-When you report search-related issues (slow or failing searches, incomplete results, high cluster CPU), Quilt support may ask you to collect diagnostics from your deployment's Elasticsearch/OpenSearch domain: CloudWatch performance metrics, plus cluster-state files that must be collected from inside the Quilt stack's VPC (the domain is VPC-internal in most deployments). This article shows how to do both with AWS CloudShell and a short read-only script — no software installation required.
+When you report search-related issues (slow or failing searches, incomplete results, high cluster CPU), Quilt support may ask for diagnostics from your deployment's Elasticsearch/OpenSearch domain: CloudWatch performance metrics, plus cluster-state files collected from inside the stack's VPC (the domain is VPC-internal in most deployments). This article shows how to do both with AWS CloudShell and a short read-only script — no software installation required.
 
 ---
 
@@ -27,7 +27,7 @@ Cluster state — four files describing shard layout, index sizes, disk allocati
 
 Plus one line of text: the domain's engine version (from Step 2).
 
-The metric files contain only numbers and timestamps. The cluster-state files contain index names (which mirror your registered bucket names), document counts, shard and disk statistics, and index configuration — no object contents, document data, or credentials.
+Nothing here contains object data or credentials; index names in the cluster-state files mirror your registered bucket names.
 
 ## Step 1 — Check your credentials
 
@@ -58,7 +58,7 @@ aws opensearch describe-domain --domain-name <DOMAIN_NAME> --region <REGION> \
 
 Note all three — the endpoint and VPC are used below; include the engine version in what you send to support. If you run several Quilt stacks, the `vpc` value tells you which stack's VPC a domain belongs to.
 
-(If `endpoint` comes back null, your domain has a public endpoint instead — check `--query 'DomainStatus.Endpoint'`. In that case skip Step 4 entirely and run the Step 5 script from any shell, using that endpoint as `HOST`.)
+(A null `endpoint` means the domain has a public endpoint instead — `DomainStatus.Endpoint`; then skip Step 4 and run the Step 5 script from any shell.)
 
 ## Step 3 — Export CloudWatch metrics
 
@@ -90,19 +90,17 @@ In a standard CloudShell you can download the files directly: **Actions → Down
 
 The domain only accepts connections from members of one security group in your Quilt stack: `…SearchClusterAccessorSecurityGroup…`. Find it in the EC2 console by its description — *"For resources that need access to search cluster"* — or in the CloudFormation stack's Resources tab under the logical ID `SearchClusterAccessorSecurityGroup`.
 
-(CloudShell isn't mandatory: any host inside the stack VPC with that security group, the Step 1 credentials, and python3 + boto3 can run the Step 5 script — then copy the files off it however you normally would; Step 6 and Cleanup are CloudShell-specific. The path below uses CloudShell, which works even in a VPC with no internet access.)
-
-In **CloudShell** (in your stack's region), create a new **VPC environment**. Two constraints to know before creating: you can have at most **two** VPC environments per user, and an environment's network settings can't be changed after creation — delete and recreate instead. Fill in:
+In **CloudShell** (in your stack's region), create a new **VPC environment**. Before creating, know: at most **two** VPC environments per user, and network settings are fixed at creation — delete and recreate to change them. Fill in:
 
 - **VPC**: the `vpc` value from Step 2.
-- **Subnet**: any subnet in the VPC can reach the domain. Step 6 additionally needs a route to S3 — in a Quilt-created VPC every subnet has one (S3 gateway endpoint), so pick any; in a customer-managed VPC prefer a subnet that can reach S3 through an S3 gateway endpoint, NAT, or your network's usual egress path (e.g. Transit Gateway).
+- **Subnet**: any subnet reaches the domain, but Step 6 needs an S3 route from it. Quilt-created VPCs: every subnet has one (S3 gateway endpoint) — pick any. Customer-managed VPCs: pick a subnet with an S3 gateway endpoint, NAT, or your usual egress path (e.g. Transit Gateway).
 - **Security group**: the one from above.
 
 Provisioning takes a minute or two; you're ready when the new environment opens with a shell prompt.
 
 ## Step 5 — Collect the cluster state
 
-Requests to the domain must be SigV4-signed; the script below signs them with your session's credentials using CloudShell's preinstalled Python and boto3. The request paths are fixed: AWS-managed domains only accept an allowlisted subset of the Elasticsearch REST API (for example, `/_all/_settings` is allowed but bare `/_settings` is rejected).
+Requests to the domain must be SigV4-signed; the script below signs them with your session's credentials using CloudShell's preinstalled Python and boto3. The request paths are fixed: AWS-managed domains accept only an allowlisted subset of the Elasticsearch REST API.
 
 Fill in the two placeholders — `<VPC_ENDPOINT>` is the `endpoint` value from Step 2, pasted as-is (no `https://` prefix); `<REGION>` is your stack's region, as in Step 2 — then paste the whole block:
 


### PR DESCRIPTION
New article: how a customer collects search diagnostics — CloudWatch domain metrics plus read-only cluster state (`_cat/shards`, `_cat/indices`, `_cat/allocation`, `_all/_settings`) from their deployment's VPC-internal search domain — including how to get a shell inside the stack VPC via a CloudShell VPC environment, the security group involved, and the least-privilege IAM requirements.

Written for reuse on any search-performance ticket. Follows the repo template shape (question title / Tags / Summary / steps).

Validation notes: the cluster-state requests were verified against a staging deployment's AWS-managed VPC domain (via in-VPC SigV4 requests — the same botocore path the article's script uses) and against stock Elasticsearch 6.8 and 7.10 locally; the CloudWatch export loop was verified against the same staging domain. One pitfall found during validation is baked into the article: AWS-managed domains reject the bare `/_settings` route (the `_all/_settings` form is allowlisted). CloudShell UI steps come from AWS docs plus prior field use, not a scripted run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a reusable support article for collecting search-cluster diagnostics.
- Explains how to identify the deployment’s VPC endpoint and engine version.
- Documents VPC, subnet, security-group, IAM, and SigV4 prerequisites.
- Provides four diagnostic commands and troubleshooting guidance.

<h3>Confidence Score: 5/5</h3>

The documentation-only change appears safe to merge.

The commands, network prerequisites, security-group guidance, and troubleshooting steps form a coherent diagnostic workflow, with no concrete changed-code failure identified.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| howto-collect-search-cluster-diagnostics.md | Adds a clear, internally consistent procedure for collecting read-only diagnostics from a VPC-internal AWS-managed Elasticsearch/OpenSearch domain. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Identify search domain and endpoint] --> B[Open shell inside stack VPC]
  B --> C[Attach accessor and outbound security groups]
  C --> D[Confirm IAM permissions]
  D --> E[Install awscurl]
  E --> F[Collect shard, index, allocation, and settings files]
  F --> G[Send files and engine version to support]
```

<sub>Reviews (1): Last reviewed commit: ["Add article: collecting search-cluster d..."](https://github.com/quiltdata/knowledge-base/commit/5c45b279963244f4d481877b5287e62172534a1b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48618347)</sub>

<!-- /greptile_comment -->
